### PR TITLE
Enable credential-less configurations for AWS

### DIFF
--- a/input/assets_aws/assets_aws.go
+++ b/input/assets_aws/assets_aws.go
@@ -136,7 +136,7 @@ func (s *assetsAWS) Run(inputCtx input.Context, publisher stateless.Publisher) e
 	}
 }
 
-func getConfigForRegion(ctx context.Context, config Config, region string) (aws.Config, error) {
+func getAWSConfigForRegion(ctx context.Context, config Config, region string) (aws.Config, error) {
 	var options []func(*aws_config.LoadOptions) error
 	if config.AccessKeyId != "" && config.SecretAccessKey != "" {
 		credentialsProvider := credentials.StaticCredentialsProvider{
@@ -158,7 +158,7 @@ func getConfigForRegion(ctx context.Context, config Config, region string) (aws.
 
 func collectAWSAssets(ctx context.Context, regions []string, log *logp.Logger, config Config, publisher stateless.Publisher) {
 	for _, region := range regions {
-		cfg, err := getConfigForRegion(ctx, config, region)
+		cfg, err := getAWSConfigForRegion(ctx, config, region)
 		if err != nil {
 			log.Errorf("failed to create AWS config for %s: %v", region, err)
 			continue

--- a/input/assets_aws/assets_aws_test.go
+++ b/input/assets_aws/assets_aws_test.go
@@ -1,7 +1,11 @@
 package assets_aws
 
 import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/elastic-agent-libs/mapstr"
@@ -22,4 +26,49 @@ func TestAssetsAWS_publishAWSAsset_IncludesRequiredFields(t *testing.T) {
 	}
 	publisher.EXPECT().Publish(beat.Event{Fields: expectedAsset})
 	publishAWSAsset(publisher, "eu-west-1", "1234", "aws.ec2.instance", "i-1234", nil, nil, nil)
+}
+
+func TestAssetAWS_getConfigForRegion_GivenExplicitCredsInConfig_CreatesCorrectAWSConfig(t *testing.T) {
+	ctx := context.Background()
+	inputCfg := Config{
+		Regions:         []string{"eu-west-2", "eu-west-1"},
+		AccessKeyId:     "accesskey123",
+		SecretAccessKey: "secretkey123",
+		SessionToken:    "token123",
+		Period:          time.Second * 600,
+	}
+	region := "eu-west-2"
+	awsCfg, err := getAWSConfigForRegion(ctx, inputCfg, region)
+	assert.NoError(t, err)
+	retrievedAWSCreds, err := awsCfg.Credentials.Retrieve(context.Background())
+	assert.NoError(t, err)
+
+	assert.Equal(t, inputCfg.AccessKeyId, retrievedAWSCreds.AccessKeyID)
+	assert.Equal(t, inputCfg.SecretAccessKey, retrievedAWSCreds.SecretAccessKey)
+	assert.Equal(t, inputCfg.SessionToken, retrievedAWSCreds.SessionToken)
+	assert.Equal(t, region, awsCfg.Region)
+}
+
+func TestAssetAWS_getConfigForRegion_GivenLocalCreds_CreatesCorrectAWSConfig(t *testing.T) {
+	ctx := context.Background()
+	accessKey := "EXAMPLE_ACCESS_KEY"
+	secretKey := "EXAMPLE_SECRETE_KEY"
+	os.Setenv("AWS_ACCESS_KEY", accessKey)
+	os.Setenv("AWS_SECRET_ACCESS_KEY", secretKey)
+	inputCfg := Config{
+		Regions:         []string{"eu-west-2", "eu-west-1"},
+		AccessKeyId:     "",
+		SecretAccessKey: "",
+		SessionToken:    "",
+		Period:          time.Second * 600,
+	}
+	region := "eu-west-2"
+	awsCfg, err := getAWSConfigForRegion(ctx, inputCfg, region)
+	assert.NoError(t, err)
+	retrievedAWSCreds, err := awsCfg.Credentials.Retrieve(context.Background())
+	assert.NoError(t, err)
+
+	assert.Equal(t, accessKey, retrievedAWSCreds.AccessKeyID)
+	assert.Equal(t, secretKey, retrievedAWSCreds.SecretAccessKey)
+	assert.Equal(t, region, awsCfg.Region)
 }


### PR DESCRIPTION
This PR enables "credential-less" configurations for the AWS assets input. When access/secret key are not provided, the default profile will be loaded

I followed a similar approach to what done in [libbeat](https://github.com/elastic/beats/blob/main/x-pack/libbeat/common/aws/credentials.go)

- closes https://github.com/elastic/inputrunner/issues/5