### PR TITLE
Move publishAWSAssets, and refactor its test to reduce repetition

### DIFF
--- a/input/assets_aws/assets_aws.go
+++ b/input/assets_aws/assets_aws.go
@@ -19,17 +19,14 @@ package assets_aws
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	input "github.com/elastic/inputrunner/input/v2"
 	stateless "github.com/elastic/inputrunner/input/v2/input-stateless"
 
-	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/feature"
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
-	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/go-concert/ctxtool"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -155,35 +152,4 @@ func collectAWSAssets(ctx context.Context, regions []string, log *logp.Logger, c
 		go collectVPCAssets(ctx, cfg, log, publisher)
 		go collectSubnetAssets(ctx, cfg, log, publisher)
 	}
-}
-
-func publishAWSAsset(publisher stateless.Publisher, region, account, assetType, assetId string, parents, children []string, tags map[string]string, metadata mapstr.M) {
-	asset := mapstr.M{
-		"cloud.provider":   "aws",
-		"cloud.region":     region,
-		"cloud.account.id": account,
-
-		"asset.type": assetType,
-		"asset.id":   assetId,
-		"asset.ean":  fmt.Sprintf("%s:%s", assetType, assetId),
-	}
-
-	if parents != nil {
-		asset["asset.parents"] = parents
-	}
-
-	if children != nil {
-		asset["asset.children"] = children
-	}
-
-	assetMetadata := mapstr.M{}
-	if tags != nil {
-		assetMetadata["tags"] = tags
-	}
-	assetMetadata.Update(metadata)
-	if len(assetMetadata) != 0 {
-		asset["asset.metadata"] = assetMetadata
-	}
-
-	publisher.Publish(beat.Event{Fields: asset})
 }

--- a/input/assets_aws/assets_aws_test.go
+++ b/input/assets_aws/assets_aws_test.go
@@ -2,54 +2,12 @@ package assets_aws
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/elastic-agent-libs/mapstr"
-	"github.com/elastic/inputrunner/mocks"
-	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 )
-
-func TestAssetsAWS_publishAWSAsset_IncludesRequiredFields(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	publisher := mocks.NewMockPublisher(ctrl)
-	expectedAsset := mapstr.M{
-		"cloud.provider":   "aws",
-		"cloud.region":     "eu-west-1",
-		"cloud.account.id": "1234",
-		"asset.type":       "aws.ec2.instance",
-		"asset.id":         "i-1234",
-		"asset.ean":        "aws.ec2.instance:i-1234",
-	}
-	publisher.EXPECT().Publish(beat.Event{Fields: expectedAsset})
-	publishAWSAsset(publisher, "eu-west-1", "1234", "aws.ec2.instance", "i-1234", nil, nil, nil, nil)
-}
-
-func TestAssetsAWS_publishAWSAsset_IncludesTagsInMetadata(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	publisher := mocks.NewMockPublisher(ctrl)
-	expectedAsset := mapstr.M{
-		"cloud.provider":   "aws",
-		"cloud.region":     "eu-west-1",
-		"cloud.account.id": "1234",
-		"asset.type":       "aws.ec2.instance",
-		"asset.id":         "i-1234",
-		"asset.ean":        "aws.ec2.instance:i-1234",
-		"asset.metadata": mapstr.M{
-			"tags": map[string]string{
-				"tag1": "a",
-				"tag2": "b",
-			},
-		},
-	}
-	publisher.EXPECT().Publish(beat.Event{Fields: expectedAsset})
-
-	tags := map[string]string{"tag1": "a", "tag2": "b"}
-	publishAWSAsset(publisher, "eu-west-1", "1234", "aws.ec2.instance", "i-1234", nil, nil, tags, nil)
-}
 
 func TestAssetAWS_getConfigForRegion_GivenExplicitCredsInConfig_CreatesCorrectAWSConfig(t *testing.T) {
 	ctx := context.Background()

--- a/input/assets_aws/publish.go
+++ b/input/assets_aws/publish.go
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package assets_aws
+
+import (
+	"fmt"
+
+	stateless "github.com/elastic/inputrunner/input/v2/input-stateless"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+)
+
+func publishAWSAsset(publisher stateless.Publisher, region, account, assetType, assetID string, parents, children []string, tags map[string]string, metadata mapstr.M) {
+	asset := mapstr.M{
+		"cloud.provider":   "aws",
+		"cloud.region":     region,
+		"cloud.account.id": account,
+
+		"asset.type": assetType,
+		"asset.id":   assetID,
+		"asset.ean":  fmt.Sprintf("%s:%s", assetType, assetID),
+	}
+
+	if parents != nil {
+		asset["asset.parents"] = parents
+	}
+
+	if children != nil {
+		asset["asset.children"] = children
+	}
+
+	assetMetadata := mapstr.M{}
+	if tags != nil {
+		assetMetadata["tags"] = tags
+	}
+	assetMetadata.Update(metadata)
+	if len(assetMetadata) != 0 {
+		asset["asset.metadata"] = assetMetadata
+	}
+
+	publisher.Publish(beat.Event{Fields: asset})
+}

--- a/input/assets_aws/publish_test.go
+++ b/input/assets_aws/publish_test.go
@@ -1,0 +1,105 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package assets_aws
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/elastic-agent-libs/mapstr"
+	"github.com/elastic/inputrunner/mocks"
+	"github.com/golang/mock/gomock"
+)
+
+func TestPublishAWSAsset(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		event beat.Event
+
+		region    string
+		account   string
+		assetType string
+		assetID   string
+		parents   []string
+		children  []string
+		tags      map[string]string
+		metadata  mapstr.M
+	}{
+		{
+			name: "required fields",
+			event: beat.Event{
+				Fields: mapstr.M{
+					"cloud.provider":   "aws",
+					"cloud.region":     "eu-west-1",
+					"cloud.account.id": "1234",
+					"asset.type":       "aws.ec2.instance",
+					"asset.id":         "i-1234",
+					"asset.ean":        "aws.ec2.instance:i-1234",
+				},
+			},
+
+			region:    "eu-west-1",
+			account:   "1234",
+			assetType: "aws.ec2.instance",
+			assetID:   "i-1234",
+		},
+		{
+			name: "includes tags in metadata",
+			event: beat.Event{
+				Fields: mapstr.M{
+					"cloud.provider":   "aws",
+					"cloud.region":     "eu-west-1",
+					"cloud.account.id": "1234",
+					"asset.type":       "aws.ec2.instance",
+					"asset.id":         "i-1234",
+					"asset.ean":        "aws.ec2.instance:i-1234",
+					"asset.metadata": mapstr.M{
+						"tags": map[string]string{
+							"tag1": "a",
+							"tag2": "b",
+						},
+					},
+				},
+			},
+
+			region:    "eu-west-1",
+			account:   "1234",
+			assetType: "aws.ec2.instance",
+			assetID:   "i-1234",
+			tags:      map[string]string{"tag1": "a", "tag2": "b"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			publisher := mocks.NewMockPublisher(ctrl)
+
+			publisher.EXPECT().Publish(tt.event)
+			publishAWSAsset(
+				publisher,
+				tt.region,
+				tt.account,
+				tt.assetType,
+				tt.assetID,
+				tt.parents,
+				tt.children,
+				tt.tags,
+				tt.metadata,
+			)
+		})
+	}
+}


### PR DESCRIPTION
This does two things:

* Move `publishAWSAsset` into its own file, for better readability.
* Refactor the method's tests to use subtests and reduce repetition.

Reading this, I'm still a bit troubled by the number of arguments, and I think if we could make the method more readable by using [functional options](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis), though it would increase complexity by having one method for each argument.