### PR TITLE
Avoid repetition of go version in CI, and run unit tests in a matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,6 @@ jobs:
           path: coverage*
 
   integration-test:
-    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -98,7 +97,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: ${{ env.DEFAULT_GO_VERSION }}
           cache: true
 
       - name: Run integration tests


### PR DESCRIPTION
This avoid repeating the current Go version in every CI step, and runs unit tests in a matrix so we can test every supported version.