### PR TITLE
Setup CI cache for Go modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           go-version: 1.19
           cache: true
+      - name: Module cache
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Check format
         uses: magefile/mage-action@v2
@@ -38,6 +43,11 @@ jobs:
       with:
         go-version: 1.19
         cache: true
+    - name: Module cache
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: go-mod-${{ hashFiles('**/go.sum') }}
 
     - name: Build
       uses: magefile/mage-action@v2
@@ -55,6 +65,11 @@ jobs:
         with:
           go-version: 1.19
           cache: true
+      - name: Module cache
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Check
         # right now the checker is a bit too strict...
@@ -75,6 +90,11 @@ jobs:
         with:
           go-version: 1.19
           cache: true
+      - name: Module cache
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Run unit tests
         uses: magefile/mage-action@v2
@@ -99,6 +119,11 @@ jobs:
         with:
           go-version: 1.19
           cache: true
+      - name: Module cache
+        uses: actions/cache@v3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Run integration tests
         uses: magefile/mage-action@v2


### PR DESCRIPTION
This caches the downloaded Go modules (and resets the cache whenever `go.mod` changes), so we don't need to fetch them every time we run CI.