### PR TITLE
Remove publish validation

### DIFF
--- a/input/assets/aws/asset_test.go
+++ b/input/assets/aws/asset_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/elastic/inputrunner/input/assets/internal"
 	"github.com/elastic/inputrunner/mocks"
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestWithAssetTags(t *testing.T) {
@@ -34,7 +33,6 @@ func TestWithAssetTags(t *testing.T) {
 
 		opts          []internal.AssetOption
 		expectedEvent beat.Event
-		expectedError error
 	}{
 		{
 			name: "with valid tags",
@@ -68,18 +66,9 @@ func TestWithAssetTags(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			publisher := mocks.NewMockPublisher(ctrl)
+			publisher.EXPECT().Publish(tt.expectedEvent)
 
-			if tt.expectedError == nil {
-				publisher.EXPECT().Publish(tt.expectedEvent)
-			}
-
-			err := internal.Publish(publisher, tt.opts...)
-
-			if tt.expectedError != nil {
-				assert.Equal(t, tt.expectedError, err)
-			} else {
-				assert.NoError(t, err)
-			}
+			internal.Publish(publisher, tt.opts...)
 		})
 	}
 }

--- a/input/assets/aws/ec2.go
+++ b/input/assets/aws/ec2.go
@@ -53,7 +53,7 @@ func collectEC2Assets(ctx context.Context, cfg aws.Config, log *logp.Logger, pub
 		if instance.SubnetID != "" {
 			parents = []string{instance.SubnetID}
 		}
-		err := internal.Publish(publisher,
+		internal.Publish(publisher,
 			internal.WithAssetCloudProvider("aws"),
 			internal.WithAssetRegion(cfg.Region),
 			internal.WithAssetAccountID(instance.OwnerID),
@@ -62,9 +62,6 @@ func collectEC2Assets(ctx context.Context, cfg aws.Config, log *logp.Logger, pub
 			WithAssetTags(flattenEC2Tags(instance.Tags)),
 			internal.WithAssetMetadata(instance.Metadata),
 		)
-		if err != nil {
-			return fmt.Errorf("publish error: %w", err)
-		}
 	}
 
 	return nil

--- a/input/assets/aws/eks.go
+++ b/input/assets/aws/eks.go
@@ -19,7 +19,6 @@ package aws
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/elastic/inputrunner/input/assets/internal"
@@ -49,7 +48,7 @@ func collectEKSAssets(ctx context.Context, cfg aws.Config, log *logp.Logger, pub
 			}
 
 			clusterARN, _ := arn.Parse(*clusterDetail.Arn)
-			err := internal.Publish(publisher,
+			internal.Publish(publisher,
 				internal.WithAssetCloudProvider("aws"),
 				internal.WithAssetRegion(cfg.Region),
 				internal.WithAssetAccountID(clusterARN.AccountID),
@@ -60,9 +59,6 @@ func collectEKSAssets(ctx context.Context, cfg aws.Config, log *logp.Logger, pub
 					"status": clusterDetail.Status,
 				}),
 			)
-			if err != nil {
-				return fmt.Errorf("publish error: %w", err)
-			}
 		}
 	}
 

--- a/input/assets/aws/vpc.go
+++ b/input/assets/aws/vpc.go
@@ -40,7 +40,7 @@ func collectVPCAssets(ctx context.Context, cfg aws.Config, log *logp.Logger, pub
 	}
 
 	for _, vpc := range vpcs {
-		err := internal.Publish(publisher,
+		internal.Publish(publisher,
 			internal.WithAssetCloudProvider("aws"),
 			internal.WithAssetRegion(cfg.Region),
 			internal.WithAssetAccountID(*vpc.OwnerId),
@@ -50,9 +50,6 @@ func collectVPCAssets(ctx context.Context, cfg aws.Config, log *logp.Logger, pub
 				"isDefault": vpc.IsDefault,
 			}),
 		)
-		if err != nil {
-			return fmt.Errorf("publish error: %w", err)
-		}
 	}
 
 	return nil
@@ -66,7 +63,7 @@ func collectSubnetAssets(ctx context.Context, cfg aws.Config, log *logp.Logger, 
 	}
 
 	for _, subnet := range subnets {
-		err := internal.Publish(publisher,
+		internal.Publish(publisher,
 			internal.WithAssetRegion(cfg.Region),
 			internal.WithAssetAccountID(*subnet.OwnerId),
 			internal.WithAssetTypeAndID("aws.subnet", *subnet.SubnetId),
@@ -76,9 +73,6 @@ func collectSubnetAssets(ctx context.Context, cfg aws.Config, log *logp.Logger, 
 				"state": string(subnet.State),
 			}),
 		)
-		if err != nil {
-			return fmt.Errorf("publish error: %w", err)
-		}
 	}
 
 	return nil

--- a/input/assets/gcp/asset_test.go
+++ b/input/assets/gcp/asset_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/elastic/inputrunner/input/assets/internal"
 	"github.com/elastic/inputrunner/mocks"
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestWithAssetLabels(t *testing.T) {
@@ -34,7 +33,6 @@ func TestWithAssetLabels(t *testing.T) {
 
 		opts          []internal.AssetOption
 		expectedEvent beat.Event
-		expectedError error
 	}{
 		{
 			name: "with valid labels",
@@ -68,18 +66,9 @@ func TestWithAssetLabels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			publisher := mocks.NewMockPublisher(ctrl)
+			publisher.EXPECT().Publish(tt.expectedEvent)
 
-			if tt.expectedError == nil {
-				publisher.EXPECT().Publish(tt.expectedEvent)
-			}
-
-			err := internal.Publish(publisher, tt.opts...)
-
-			if tt.expectedError != nil {
-				assert.Equal(t, tt.expectedError, err)
-			} else {
-				assert.NoError(t, err)
-			}
+			internal.Publish(publisher, tt.opts...)
 		})
 	}
 }

--- a/input/assets/gcp/compute.go
+++ b/input/assets/gcp/compute.go
@@ -52,7 +52,7 @@ func collectComputeAssets(ctx context.Context, cfg config, publisher stateless.P
 		var parents []string
 		parents = append(parents, instance.Networks...)
 
-		err = internal.Publish(publisher,
+		internal.Publish(publisher,
 			internal.WithAssetCloudProvider("gcp"),
 			internal.WithAssetRegion(instance.Region),
 			internal.WithAssetAccountID(instance.Account),
@@ -61,9 +61,6 @@ func collectComputeAssets(ctx context.Context, cfg config, publisher stateless.P
 			WithAssetLabels(instance.Labels),
 			internal.WithAssetMetadata(instance.Metadata),
 		)
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/input/assets/internal/publish.go
+++ b/input/assets/internal/publish.go
@@ -29,7 +29,7 @@ type AssetOption func(beat.Event) beat.Event
 
 // Publish emits a `beat.Event` to the specified publisher, with the provided
 // parameters
-func Publish(publisher stateless.Publisher, opts ...AssetOption) error {
+func Publish(publisher stateless.Publisher, opts ...AssetOption) {
 	event := beat.Event{Fields: mapstr.M{}}
 
 	for _, o := range opts {
@@ -37,7 +37,6 @@ func Publish(publisher stateless.Publisher, opts ...AssetOption) error {
 	}
 
 	publisher.Publish(event)
-	return nil
 }
 
 func WithAssetCloudProvider(value string) AssetOption {

--- a/input/assets/internal/publish_test.go
+++ b/input/assets/internal/publish_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/mapstr"
 	"github.com/elastic/inputrunner/mocks"
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPublish(t *testing.T) {
@@ -121,8 +120,7 @@ func TestPublish(t *testing.T) {
 			publisher := mocks.NewMockPublisher(ctrl)
 			publisher.EXPECT().Publish(tt.expectedEvent)
 
-			err := Publish(publisher, tt.opts...)
-			assert.NoError(t, err)
+			Publish(publisher, tt.opts...)
 		})
 	}
 }


### PR DESCRIPTION
Based on the discussion in https://github.com/elastic/inputrunner/pull/55#discussion_r1129518570, I am removing the validation for Publish.

I am keeping returning an error, as this method is effectively making an external call, so we'll need to check for errors at some point, and being able to return an error here will make this much easier.