### PR TITLE
Align `asset_types` with published `asset.type` field for the AWS input

### DIFF
--- a/input/assets/aws/aws.go
+++ b/input/assets/aws/aws.go
@@ -152,28 +152,30 @@ func collectAWSAssets(ctx context.Context, log *logp.Logger, cfg config, publish
 			}()
 		}
 		if internal.IsTypeEnabled(cfg.AssetTypes, "aws.ec2.instance") {
+			ec2Region := region
 			go func() {
 				client := ec2.NewFromConfig(awsCfg)
-				err := collectEC2Assets(ctx, client, region, indexNamespace, log, publisher)
+				err := collectEC2Assets(ctx, client, ec2Region, indexNamespace, log, publisher)
 				if err != nil {
 					log.Errorf("error collecting EC2 assets: %w", err)
 				}
 			}()
 		}
 		if internal.IsTypeEnabled(cfg.AssetTypes, "aws.vpc") {
-			// should these just go in the same function??
+			vpcRegion := region
 			go func() {
 				client := ec2.NewFromConfig(awsCfg)
-				err := collectVPCAssets(ctx, client, region, indexNamespace, log, publisher)
+				err := collectVPCAssets(ctx, client, vpcRegion, indexNamespace, log, publisher)
 				if err != nil {
 					log.Errorf("error collecting VPC assets: %w", err)
 				}
 			}()
 		}
 		if internal.IsTypeEnabled(cfg.AssetTypes, "aws.subnet") {
+			subnetRegion := region
 			go func() {
 				client := ec2.NewFromConfig(awsCfg)
-				err := collectSubnetAssets(ctx, client, region, indexNamespace, log, publisher)
+				err := collectSubnetAssets(ctx, client, subnetRegion, indexNamespace, log, publisher)
 				if err != nil {
 					log.Errorf("error collecting Subnet assets: %w", err)
 				}


### PR DESCRIPTION
- related to https://github.com/elastic/inputrunner/issues/183