### PR TITLE
[assets_gcp] Add basic documentation

### DIFF
--- a/input/assets/gcp/README.md
+++ b/input/assets/gcp/README.md
@@ -103,6 +103,8 @@ The following GCP API permissions are required for the GCP Assets Input to funct
 
 ### Compute Engine instances
 
+#### Exported fields
+
 | Field                              | Description                                                                                                                                       | Example                                      |
 |------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|
 | asset.type                         | The type of asset                                                                                                                                 | `"gcp.compute.instance"`                     |


### PR DESCRIPTION
Initial docs for GCP

- relates to https://github.com/elastic/inputrunner/issues/193