### PR TITLE
Set mage build ubuntu version to 20:04 like in dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,6 @@ name: docker
 on:
   merge_group:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This PR sets the image used for `mage build` command of docker ci `pkg-docker` step  to ubuntu-20.04 instead of ubuntu-latest.

The reason is that the inputrunner binary needs to be build by the same os version as the docker image of the container it is going to run in.
 In the Dockerfile image ubuntu:20.04 was set as base image.

Resolves https://github.com/elastic/inputrunner/issues/198