### PR TITLE
[CI] Fix Docker releases and CSV report generation in Buildkite

### DIFF
--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -18,7 +18,7 @@ source $MY_DIR/install-prereq.sh
 go mod download
 
 # Packaging the assetbeat binary
-mage package
+# mage package
 
 # Generate the CSV dependency report
 mage dependencyReport

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -21,7 +21,6 @@ go mod download
 # mage package
 
 echo $PWD
-echo $GIT_DIR
 echo $BUILDKITE_BUILD_CHECKOUT_PATH
 
 # Generate the CSV dependency report

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -10,18 +10,16 @@ if [ "$WORKFLOW" = "snapshot" ] ; then
     export SNAPSHOT="true"
 fi
 
-git status
 
+# Install prerequirements (go, mage...)
+MY_DIR=$(dirname $(readlink -f "$0"))
+source $MY_DIR/install-prereq.sh
 
-## Install prerequirements (go, mage...)
-#MY_DIR=$(dirname $(readlink -f "$0"))
-#source $MY_DIR/install-prereq.sh
-#
-## Download Go dependencies
-#go mod download
-#
-## Packaging the assetbeat binary
-#mage package
-#
-## Generate the CSV dependency report
-#mage dependencyReport
+# Download Go dependencies
+go mod download
+
+# Packaging the assetbeat binary
+mage package
+
+# Generate the CSV dependency report
+mage dependencyReport

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -22,5 +22,7 @@ go mod download
 
 echo $PWD
 ls -alrt
+
+git --git-dir="$PWD/.git" rev-parse > /dev/null 2>&1
 # Generate the CSV dependency report
 mage dependencyReport

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -21,7 +21,6 @@ go mod download
 # mage package
 
 echo $PWD
-echo $BUILDKITE_BUILD_CHECKOUT_PATH
-
+ls -alrt
 # Generate the CSV dependency report
 mage dependencyReport

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -19,3 +19,6 @@ go mod download
 
 # Packaging the assetbeat binary
 mage package
+
+# Generate the CSV dependency report
+mage dependencyReport

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -10,19 +10,18 @@ if [ "$WORKFLOW" = "snapshot" ] ; then
     export SNAPSHOT="true"
 fi
 
-# Install prerequirements (go, mage...)
-MY_DIR=$(dirname $(readlink -f "$0"))
-source $MY_DIR/install-prereq.sh
+git status
 
-# Download Go dependencies
-go mod download
 
-# Packaging the assetbeat binary
-# mage package
-
-echo $PWD
-ls -alrt
-
-git --git-dir="$PWD/.git" rev-parse > /dev/null 2>&1
-# Generate the CSV dependency report
-mage dependencyReport
+## Install prerequirements (go, mage...)
+#MY_DIR=$(dirname $(readlink -f "$0"))
+#source $MY_DIR/install-prereq.sh
+#
+## Download Go dependencies
+#go mod download
+#
+## Packaging the assetbeat binary
+#mage package
+#
+## Generate the CSV dependency report
+#mage dependencyReport

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -20,5 +20,9 @@ go mod download
 # Packaging the assetbeat binary
 # mage package
 
+echo $PWD
+echo $GIT_DIR
+echo $BUILDKITE_BUILD_CHECKOUT_PATH
+
 # Generate the CSV dependency report
 mage dependencyReport

--- a/internal/dev-tools/notice.go
+++ b/internal/dev-tools/notice.go
@@ -28,7 +28,7 @@ import (
 )
 
 func GenerateNotice(overrides, rules, noticeTemplate string) error {
-
+	mg.Deps(mage.InstallGoNoticeGen)
 	depsFile := generateDepsFile()
 	defer os.Remove(depsFile)
 
@@ -44,7 +44,7 @@ func GenerateNotice(overrides, rules, noticeTemplate string) error {
 }
 
 func GenerateDependencyReport(overrides, rules, dependencyReportTemplate string, isSnapshot bool) error {
-
+	mg.Deps(mage.InstallGoNoticeGen)
 	depsFile := generateDepsFile()
 	defer os.Remove(depsFile)
 
@@ -68,10 +68,6 @@ func GenerateDependencyReport(overrides, rules, dependencyReportTemplate string,
 }
 
 func generateDepsFile() string {
-	mg.Deps(mage.InstallGoNoticeGen, mage.Deps.CheckModuleTidy)
-
-	gotool.Mod.Tidy()     //nolint:errcheck // No value in handling this error.
-	gotool.Mod.Download() //nolint:errcheck // No value in handling this error.
 
 	out, _ := gotool.ListDepsForNotice()
 	depsFile, _ := os.CreateTemp("", "depsout")

--- a/magefile.go
+++ b/magefile.go
@@ -200,7 +200,7 @@ func Package() error {
 			}
 		}
 	}
-	return DependencyReport()
+	return nil
 }
 
 func isSnapshot() bool {


### PR DESCRIPTION
## What does this PR do

* Remove (failing) CSV report generation step for Docker builds, as not really required right now.
* Remove `go mod init` and `go mod download` calls from NOTICE and CSV report generation logic. These steps are already performed as part of `package.sh` and/or `mage check/update`.
