### PR TITLE
Add post-dependabot GH action to update NOTICE.txt

### DIFF
--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -1,0 +1,47 @@
+# Follow-on actions relating to dependabot PRs. In elastic/beats, any changes to
+# dependencies contained in go.mod requires the change to be reflected in the
+# NOTICE.txt file. When dependabot creates a branch for a go_modules change this
+# will update the NOTICE.txt file for that change.
+name: post-dependabot
+
+on:
+  push:
+    branches:
+      - 'dependabot/go_modules/**'
+
+env:
+  DEFAULT_GO_VERSION: "1.20"
+jobs:
+  update-notice:
+    permissions:
+      # Allow job to write to the branch.
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.DEFAULT_GO_VERSION }}
+          cache: true
+
+      - name: update notice
+        uses: magefile/mage-action@v2
+        with:
+          version: latest
+          args: notice
+
+      - name: check for modified NOTICE.txt
+        id: notice-check
+        run: echo "modified=$(if git status --porcelain --untracked-files=no | grep -q -E ' NOTICE.txt$'; then echo "true"; else echo "false"; fi)" >> $GITHUB_OUTPUT
+
+      - name: commit NOTICE.txt
+        if: steps.notice-check.outputs.modified == 'true'
+        run: |
+          git config --global user.name 'dependabot[bot]'
+          git config --global user.email 'dependabot[bot]@users.noreply.github.com'
+          git add NOTICE.txt
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git commit -m "Update NOTICE.txt"
+          git push


### PR DESCRIPTION
## What does this PR do?

In `assetbeat`, any changes to dependencies contained in go.mod requires the change to be reflected in the NOTICE.txt file. When dependabot creates a branch for a go_modules change this will update the NOTICE.txt file for that change.

## Why is it important?

It avoids having dependabot PRs immediately fail to pass CI checks because of an out-of-date NOTICE.txt file. This saves a developer from having to manually update dependabot PRs.