### PR TITLE
Revert to default values for `skip_pull_request_builds_for_existing_commits`, `separate_pull_request_statuses` and `publish_commit_status_per_step`

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -39,10 +39,7 @@ spec:
       provider_settings:
         build_pull_requests: true
         publish_commit_status: true
-        publish_commit_status_per_step: true
         publish_blocked_as_pending: true
-        separate_pull_request_statuses: false
-        skip_pull_request_builds_for_existing_commits: false
         cancel_deleted_branch_builds: true
       teams:
         observability-asset-management:


### PR DESCRIPTION
This PR removes the following entries from `provider_settings` in `catalog-info.yml`, reverting to their default values

* skip_pull_request_builds_for_existing_commits: (Optional, Default: True) Whether to skip creating a new build for a pull request if an existing build for the commit and branch already exists.

* separate_pull_request_statuses: (Optional, Default: False) Whether to create a separate status for pull request builds, allowing you to require a passing pull request build in your [required status checks](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/managing-a-branch-protection-rule) in GitHub.

* publish_commit_status_per_step: (Optional, Default: False) Whether to create a separate status for each job in a build, allowing you to see the status of each job directly in Bitbucket or GitHub.