### PR TITLE
Use x86_64 suffix in artifact names instead of amd64

### DIFF
--- a/internal/dev-tools/package.go
+++ b/internal/dev-tools/package.go
@@ -36,6 +36,18 @@ type PackageSpec struct {
 	ExtraFilesList []string
 }
 
+var packageArchOverrides = map[string]string{
+	"amd64": "x86_64",
+}
+
+func GetPackageArch(goarch string) string {
+	arch, overrideExists := packageArchOverrides[goarch]
+	if overrideExists {
+		return arch
+	}
+	return goarch
+}
+
 // GetDefaultExtraFiles returns the default list of files to include in an assetbeat package,
 // in addition to assetbeat's executable
 func GetDefaultExtraFiles() []string {

--- a/magefile.go
+++ b/magefile.go
@@ -188,7 +188,7 @@ func Package() error {
 			fmt.Printf(">>>>> Packaging assetbeat for platform: %+v packageType:%s\n", platform, packageType)
 			packageSpec := devtools.PackageSpec{
 				Os:             platform.GOOS,
-				Arch:           platform.GOARCH,
+				Arch:           devtools.GetPackageArch(platform.GOARCH),
 				PackageType:    packageType,
 				ExecutablePath: executablePath,
 				IsSnapshot:     isSnapshot(),


### PR DESCRIPTION
Elastic Agent expects to find `x86_64` as suffix for `amd64` architectures. 

- Closes https://github.com/elastic/assetbeat/issues/321