### PR TITLE
Add Elastic Agent spec file

### DIFF
--- a/assetbeat.spec.yml
+++ b/assetbeat.spec.yml
@@ -1,0 +1,49 @@
+version: 2
+inputs:
+  - name: assetbeat
+    description: "Assetbeat"
+    platforms: &platforms
+      - linux/amd64
+      - linux/arm64
+    outputs: &outputs
+      - elasticsearch
+    command: &command
+      restart_monitoring_period: 5s
+      maximum_restarts_per_period: 1
+      timeouts:
+        restart: 1s
+      args:
+        - "-E"
+        - "setup.ilm.enabled=false"
+        - "-E"
+        - "setup.template.enabled=false"
+        - "-E"
+        - "management.enabled=true"
+        - "-E"
+        - "management.restart_on_output_change=true"
+        - "-E"
+        - "logging.level=info"
+        - "-E"
+        - "logging.to_stderr=true"
+        - "-E"
+        - "gc_percent=${ASSETBEAT_GOGC:100}"
+  - name: assets_k8s
+    description: "Kubernetes assets"
+    platforms: *platforms
+    outputs: *outputs
+    command: *command
+  - name: assets_aws
+    description: "AWS assets"
+    platforms: *platforms
+    outputs: *outputs
+    command: *command
+  - name: assets_gcp
+    description: "GCP Assets"
+    platforms: *platforms
+    outputs: *outputs
+    command: *command
+  - name: assets_azure
+    description: "Azure Assets"
+    platforms: *platforms
+    outputs: *outputs
+    command: *command

--- a/internal/dev-tools/package.go
+++ b/internal/dev-tools/package.go
@@ -51,7 +51,7 @@ func GetPackageArch(goarch string) string {
 // GetDefaultExtraFiles returns the default list of files to include in an assetbeat package,
 // in addition to assetbeat's executable
 func GetDefaultExtraFiles() []string {
-	return []string{"LICENSE.txt", "README.md", "assetbeat.yml"}
+	return []string{"LICENSE.txt", "README.md", "assetbeat.yml", "assetbeat.spec.yml"}
 }
 
 // CreatePackage assetbeat for distribution. It generates packages based on the provided PackageSpec/

--- a/internal/dev-tools/tar.go
+++ b/internal/dev-tools/tar.go
@@ -65,7 +65,7 @@ func addFileToTarWriter(filePath string, tarWriter *tar.Writer) error {
 	}
 
 	headerName := filepath.Base(filePath)
-	if strings.Contains(headerName, "assetbeat") {
+	if strings.Contains(headerName, "assetbeat-") {
 		//This makes sure that platform details are removed from the packaged assetbeat binary filename
 		headerName = "assetbeat"
 	}


### PR DESCRIPTION
This PR adds the filespec yml file, to integrate Elastic Agent with `assetbeat`. It includes the currently available inputs. I used `cloudbeat` [spec](https://github.com/elastic/elastic-agent/blob/main/specs/cloudbeat.spec.yml) as reference.

Documentation about Elastic Agent components specs can be found at https://github.com/elastic/elastic-agent/blob/main/docs/component-specs.md 