### PR TITLE
Add `asset.name` for Azure assets

### DIFF
--- a/input/azure/README.md
+++ b/input/azure/README.md
@@ -47,6 +47,7 @@ The Azure Assets Input supports the following configuration options plus the [Co
 |-------------------------------|-----------------------------------|-----------------------------------------------|
 | asset.type                    | The type of asset                 | `"azure.vm.instance"`                         |
 | asset.kind                    | The kind of asset                 | `"host`                                       |
+| asset.name                    | The name of the Azure instance    | `"my_instance"`                               |
 | asset.id                      | The VM id of the Azure instance   | `"00830b08-f63d-495b-9b04-989f83c50111"`      |
 | asset.ean                     | The EAN of this specific resource | `"host:00830b08-f63d-495b-9b04-989f83c50111"` |
 | asset.metadata.resource_group | The Azure resource group          | `TESTVM`                                      |
@@ -79,6 +80,7 @@ The Azure Assets Input supports the following configuration options plus the [Co
   "asset.ean": "host:00830b08-f63d-495b-9b04-989f83c50111",
   "asset.metadata.state": "VM running",
   "asset.type": "azure.vm.instance",
+  "asset.name": "my_instance",
   "ecs": {
     "version": "8.0.0"
   }

--- a/input/azure/vm.go
+++ b/input/azure/vm.go
@@ -50,14 +50,18 @@ func collectAzureVMAssets(ctx context.Context, client *armcompute.VirtualMachine
 	log.Debug("Publishing Azure VM instances")
 
 	for _, instance := range instances {
-		internal.Publish(publisher, nil,
+		options := []internal.AssetOption{
 			internal.WithAssetCloudProvider("azure"),
 			internal.WithAssetRegion(instance.Region),
 			internal.WithAssetAccountID(instance.SubscriptionID),
 			internal.WithAssetKindAndID(assetKind, instance.ID),
 			internal.WithAssetType(assetType),
 			internal.WithAssetMetadata(instance.Metadata),
-		)
+		}
+		if instance.Name != "" {
+			options = append(options, internal.WithAssetName(instance.Name))
+		}
+		internal.Publish(publisher, nil, options...)
 	}
 
 	return nil

--- a/input/azure/vm_test.go
+++ b/input/azure/vm_test.go
@@ -121,6 +121,7 @@ func TestAssetsAzure_collectAzureAssets(t *testing.T) {
 					Fields: mapstr.M{
 						"asset.ean":                     "host:" + instanceVMId1,
 						"asset.id":                      instanceVMId1,
+						"asset.name":                    instance1Name,
 						"asset.type":                    "azure.vm.instance",
 						"asset.kind":                    "host",
 						"asset.metadata.state":          "",
@@ -137,6 +138,7 @@ func TestAssetsAzure_collectAzureAssets(t *testing.T) {
 					Fields: mapstr.M{
 						"asset.ean":                     "host:" + instanceVMId2,
 						"asset.id":                      instanceVMId2,
+						"asset.name":                    instance2Name,
 						"asset.type":                    "azure.vm.instance",
 						"asset.kind":                    "host",
 						"asset.metadata.state":          "",
@@ -153,6 +155,7 @@ func TestAssetsAzure_collectAzureAssets(t *testing.T) {
 					Fields: mapstr.M{
 						"asset.ean":                     "host:" + instanceVMId3,
 						"asset.id":                      instanceVMId3,
+						"asset.name":                    instance3Name,
 						"asset.type":                    "azure.vm.instance",
 						"asset.kind":                    "host",
 						"asset.metadata.state":          "",
@@ -192,6 +195,7 @@ func TestAssetsAzure_collectAzureAssets(t *testing.T) {
 					Fields: mapstr.M{
 						"asset.ean":                     "host:" + instanceVMId1,
 						"asset.id":                      instanceVMId1,
+						"asset.name":                    instance1Name,
 						"asset.type":                    "azure.vm.instance",
 						"asset.kind":                    "host",
 						"asset.metadata.state":          "",
@@ -208,6 +212,7 @@ func TestAssetsAzure_collectAzureAssets(t *testing.T) {
 					Fields: mapstr.M{
 						"asset.ean":                     "host:" + instanceVMId2,
 						"asset.id":                      instanceVMId2,
+						"asset.name":                    instance2Name,
 						"asset.type":                    "azure.vm.instance",
 						"asset.kind":                    "host",
 						"asset.metadata.state":          "",
@@ -249,6 +254,7 @@ func TestAssetsAzure_collectAzureAssets(t *testing.T) {
 					Fields: mapstr.M{
 						"asset.ean":                     "host:" + instanceVMId1,
 						"asset.id":                      instanceVMId1,
+						"asset.name":                    instance1Name,
 						"asset.type":                    "azure.vm.instance",
 						"asset.kind":                    "host",
 						"asset.metadata.state":          "",
@@ -265,6 +271,7 @@ func TestAssetsAzure_collectAzureAssets(t *testing.T) {
 					Fields: mapstr.M{
 						"asset.ean":                     "host:" + instanceVMId2,
 						"asset.id":                      instanceVMId2,
+						"asset.name":                    instance2Name,
 						"asset.type":                    "azure.vm.instance",
 						"asset.kind":                    "host",
 						"asset.metadata.state":          "",


### PR DESCRIPTION
Add asset.name for all the current assets published for Azure, if the resource has a human-readable name.
