### PR TITLE
Add collector for VM scale sets instances

### DIFF
--- a/input/azure/azure.go
+++ b/input/azure/azure.go
@@ -20,6 +20,8 @@ package azure
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
@@ -31,7 +33,6 @@ import (
 	conf "github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/go-concert/ctxtool"
-	"time"
 )
 
 func Plugin() input.Plugin {
@@ -64,7 +65,6 @@ type config struct {
 	ClientSecret        string   `config:"client_secret"`
 	SubscriptionID      string   `config:"subscription_id"`
 	TenantID            string   `config:"tenant_id"`
-	ResourceGroup       string   `config:"resource_group"`
 }
 
 func defaultConfig() config {
@@ -78,7 +78,6 @@ func defaultConfig() config {
 		ClientSecret:   "",
 		SubscriptionID: "",
 		TenantID:       "",
-		ResourceGroup:  "",
 	}
 }
 
@@ -148,7 +147,7 @@ func collectAzureAssets(ctx context.Context, log *logp.Logger, cfg config, publi
 			}
 			client := clientFactory.NewVirtualMachinesClient()
 			go func(currentSub string) {
-				err = collectAzureVMAssets(ctx, client, currentSub, cfg.Regions, cfg.ResourceGroup, log, publisher)
+				err = collectAzureVMAssets(ctx, client, currentSub, cfg.Regions, log, publisher)
 				if err != nil {
 					log.Errorf("Error while collecting Azure VM assets: %v", err)
 				}
@@ -156,7 +155,7 @@ func collectAzureAssets(ctx context.Context, log *logp.Logger, cfg config, publi
 			vmClient := clientFactory.NewVirtualMachineScaleSetVMsClient()
 			scaleSetsClient := clientFactory.NewVirtualMachineScaleSetsClient()
 			go func(currentSub string) {
-				err = collectAzureScaleSetsVMAssets(ctx, vmClient, scaleSetsClient, currentSub, cfg.Regions, cfg.ResourceGroup, log, publisher)
+				err = collectAzureScaleSetsVMAssets(ctx, vmClient, scaleSetsClient, currentSub, cfg.Regions, log, publisher)
 				if err != nil {
 					log.Errorf("Error while collecting Azure Scale Sets VM assets: %v", err)
 				}

--- a/input/azure/azure.go
+++ b/input/azure/azure.go
@@ -153,6 +153,14 @@ func collectAzureAssets(ctx context.Context, log *logp.Logger, cfg config, publi
 					log.Errorf("Error while collecting Azure VM assets: %v", err)
 				}
 			}(sub)
+			vmClient := clientFactory.NewVirtualMachineScaleSetVMsClient()
+			scaleSetsClient := clientFactory.NewVirtualMachineScaleSetsClient()
+			go func(currentSub string) {
+				err = collectAzureScaleSetsVMAssets(ctx, vmClient, scaleSetsClient, currentSub, cfg.Regions, cfg.ResourceGroup, log, publisher)
+				if err != nil {
+					log.Errorf("Error while collecting Azure Scale Sets VM assets: %v", err)
+				}
+			}(sub)
 		}
 	}
 }

--- a/input/azure/vm.go
+++ b/input/azure/vm.go
@@ -20,13 +20,14 @@ package azure
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/elastic/assetbeat/input/internal"
 	stateless "github.com/elastic/beats/v7/filebeat/input/v2/input-stateless"
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/mapstr"
-	"strings"
 )
 
 type AzureVMInstance struct {
@@ -38,9 +39,14 @@ type AzureVMInstance struct {
 	Metadata       mapstr.M
 }
 
-func collectAzureVMAssets(ctx context.Context, client *armcompute.VirtualMachinesClient, subscriptionId string, regions []string, resourceGroup string, log *logp.Logger, publisher stateless.Publisher) error {
+type vmScaleSet struct {
+	ID   string
+	Name string
+}
 
-	instances, err := getAllAzureVMInstances(ctx, client, subscriptionId, regions, resourceGroup)
+func collectAzureVMAssets(ctx context.Context, client *armcompute.VirtualMachinesClient, subscriptionId string, regions []string, log *logp.Logger, publisher stateless.Publisher) error {
+
+	instances, err := getAllAzureVMInstances(ctx, client, subscriptionId, regions)
 	if err != nil {
 		return err
 	}
@@ -67,30 +73,63 @@ func collectAzureVMAssets(ctx context.Context, client *armcompute.VirtualMachine
 	return nil
 }
 
-func collectAzureScaleSetsVMAssets(ctx context.Context, vmClient *armcompute.VirtualMachineScaleSetVMsClient, scaleSetClient *armcompute.VirtualMachineScaleSetsClient, subscriptionId string, regions []string, resourceGroup string, log *logp.Logger, publisher stateless.Publisher) error {
-	//TODO: move this to separate method
-	var vmScaleSets []string
+func collectAzureScaleSetsVMAssets(ctx context.Context, vmClient *armcompute.VirtualMachineScaleSetVMsClient, scaleSetClient *armcompute.VirtualMachineScaleSetsClient, subscriptionId string, regions []string, log *logp.Logger, publisher stateless.Publisher) error {
+	instances, err := getAllAzureScaleSetsVMInstances(ctx, vmClient, scaleSetClient, subscriptionId, regions, log)
+	if err != nil {
+		return err
+	}
+
+	assetType := "azure.vm.instance"
+	assetKind := "host"
+	log.Debug("Publishing Azure VM instances")
+
+	for _, instance := range instances {
+		options := []internal.AssetOption{
+			internal.WithAssetCloudProvider("azure"),
+			internal.WithAssetRegion(instance.Region),
+			internal.WithAssetAccountID(instance.SubscriptionID),
+			internal.WithAssetKindAndID(assetKind, instance.ID),
+			internal.WithAssetType(assetType),
+			internal.WithAssetMetadata(instance.Metadata),
+		}
+		if instance.Name != "" {
+			options = append(options, internal.WithAssetName(instance.Name))
+		}
+		internal.Publish(publisher, nil, options...)
+	}
+	return nil
+}
+
+func getAllAzureScaleSetsVMInstances(ctx context.Context, vmClient *armcompute.VirtualMachineScaleSetVMsClient, scaleSetClient *armcompute.VirtualMachineScaleSetsClient, subscriptionId string, regions []string, log *logp.Logger) ([]AzureVMInstance, error) {
+	var vmScaleSets []vmScaleSet
 	var vmInstances []AzureVMInstance
 	scaleSetPager := scaleSetClient.NewListAllPager(&armcompute.VirtualMachineScaleSetsClientListAllOptions{})
 	for scaleSetPager.More() {
 		page, err := scaleSetPager.NextPage(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to advance page: %v", err)
+			return nil, fmt.Errorf("failed to advance page: %v", err)
 		}
 		for _, v := range page.Value {
-			vmScaleSets = append(vmScaleSets, *v.Name)
+			vmScaleSets = append(vmScaleSets, vmScaleSet{ID: *v.ID, Name: *v.Name})
 		}
 	}
+
 	for _, vmScaleSet := range vmScaleSets {
-		pager := vmClient.NewListPager(resourceGroup, vmScaleSet, &armcompute.VirtualMachineScaleSetVMsClientListOptions{})
+		resourceGroup := getResourceGroupFromId(vmScaleSet.ID)
+		pager := vmClient.NewListPager(resourceGroup, vmScaleSet.Name, &armcompute.VirtualMachineScaleSetVMsClientListOptions{})
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to advance page: %v", err)
+			return nil, fmt.Errorf("failed to advance page: %v", err)
 		}
 		for _, v := range page.Value {
 			var status string
-			if v.Properties != nil && v.Properties.InstanceView != nil && len(v.Properties.InstanceView.Statuses) > 1 {
-				status = *v.Properties.InstanceView.Statuses[1].DisplayStatus
+			res, err := vmClient.GetInstanceView(ctx, resourceGroup, vmScaleSet.Name, *v.InstanceID, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed get the Instance View: %v", err)
+			}
+			instanceView := res.VirtualMachineScaleSetVMInstanceView
+			for _, s := range instanceView.Statuses {
+				status = *s.DisplayStatus
 			}
 			vmInstance := AzureVMInstance{
 				ID:             *v.Properties.VMID,
@@ -100,16 +139,16 @@ func collectAzureScaleSetsVMAssets(ctx context.Context, vmClient *armcompute.Vir
 				Tags:           v.Tags,
 				Metadata: mapstr.M{
 					"state":          status,
-					"resource_group": getResourceGroupFromId(*v.ID),
+					"resource_group": resourceGroup,
 				},
 			}
 			vmInstances = append(vmInstances, vmInstance)
 		}
 	}
-	return nil
+	return vmInstances, nil
 }
 
-func getAllAzureVMInstances(ctx context.Context, client *armcompute.VirtualMachinesClient, subscriptionId string, regions []string, resourceGroup string) ([]AzureVMInstance, error) {
+func getAllAzureVMInstances(ctx context.Context, client *armcompute.VirtualMachinesClient, subscriptionId string, regions []string) ([]AzureVMInstance, error) {
 	var vmInstances []AzureVMInstance
 	pager := client.NewListAllPager(&armcompute.VirtualMachinesClientListAllOptions{StatusOnly: to.Ptr("true")})
 	for pager.More() {
@@ -118,7 +157,7 @@ func getAllAzureVMInstances(ctx context.Context, client *armcompute.VirtualMachi
 			return nil, fmt.Errorf("failed to advance page: %v", err)
 		}
 		for _, v := range page.Value {
-			if wantRegion(v, regions) && wantResourceGroup(v, resourceGroup) {
+			if wantRegion(v, regions) {
 				var status string
 				if v.Properties != nil && v.Properties.InstanceView != nil && len(v.Properties.InstanceView.Statuses) > 1 {
 					status = *v.Properties.InstanceView.Statuses[1].DisplayStatus

--- a/input/azure/vm.go
+++ b/input/azure/vm.go
@@ -122,15 +122,12 @@ func getAllAzureScaleSetsVMInstances(ctx context.Context, vmClient *armcompute.V
 			return nil, fmt.Errorf("failed to advance page: %v", err)
 		}
 		for _, v := range page.Value {
-			var status string
 			res, err := vmClient.GetInstanceView(ctx, resourceGroup, vmScaleSet.Name, *v.InstanceID, nil)
 			if err != nil {
 				return nil, fmt.Errorf("failed get the Instance View: %v", err)
 			}
 			instanceView := res.VirtualMachineScaleSetVMInstanceView
-			for _, s := range instanceView.Statuses {
-				status = *s.DisplayStatus
-			}
+			lastStatus := instanceView.Statuses[len(instanceView.Statuses)-1]
 			vmInstance := AzureVMInstance{
 				ID:             *v.Properties.VMID,
 				Name:           *v.Name,
@@ -138,7 +135,7 @@ func getAllAzureScaleSetsVMInstances(ctx context.Context, vmClient *armcompute.V
 				Region:         *v.Location,
 				Tags:           v.Tags,
 				Metadata: mapstr.M{
-					"state":          status,
+					"state":          *lastStatus.DisplayStatus,
 					"resource_group": resourceGroup,
 				},
 			}

--- a/input/azure/vm.go
+++ b/input/azure/vm.go
@@ -127,7 +127,10 @@ func getAllAzureScaleSetsVMInstances(ctx context.Context, vmClient *armcompute.V
 				return nil, fmt.Errorf("failed get the Instance View: %v", err)
 			}
 			instanceView := res.VirtualMachineScaleSetVMInstanceView
-			lastStatus := instanceView.Statuses[len(instanceView.Statuses)-1]
+			var status string
+			if len(instanceView.Statuses) > 1 {
+				status = *instanceView.Statuses[len(instanceView.Statuses)-1].DisplayStatus
+			}
 			vmInstance := AzureVMInstance{
 				ID:             *v.Properties.VMID,
 				Name:           *v.Name,
@@ -135,7 +138,7 @@ func getAllAzureScaleSetsVMInstances(ctx context.Context, vmClient *armcompute.V
 				Region:         *v.Location,
 				Tags:           v.Tags,
 				Metadata: mapstr.M{
-					"state":          *lastStatus.DisplayStatus,
+					"state":          status,
 					"resource_group": resourceGroup,
 				},
 			}
@@ -157,7 +160,7 @@ func getAllAzureVMInstances(ctx context.Context, client *armcompute.VirtualMachi
 			if wantRegion(v, regions) {
 				var status string
 				if v.Properties != nil && v.Properties.InstanceView != nil && len(v.Properties.InstanceView.Statuses) > 1 {
-					status = *v.Properties.InstanceView.Statuses[1].DisplayStatus
+					status = *v.Properties.InstanceView.Statuses[len(v.Properties.InstanceView.Statuses)-1].DisplayStatus
 				}
 				vmInstance := AzureVMInstance{
 					ID:             *v.Properties.VMID,

--- a/input/azure/vm.go
+++ b/input/azure/vm.go
@@ -67,6 +67,25 @@ func collectAzureVMAssets(ctx context.Context, client *armcompute.VirtualMachine
 	return nil
 }
 
+func collectAzureScaleSetsVMAssets(ctx context.Context, vmClient *armcompute.VirtualMachineScaleSetVMsClient, scaleSetClient *armcompute.VirtualMachineScaleSetsClient, subscriptionId string, regions []string, resourceGroup string, log *logp.Logger, publisher stateless.Publisher) error {
+	//TODO: move this to separate method
+	var vmScaleSets []string
+	scaleSetPager := scaleSetClient.NewListAllPager(&armcompute.VirtualMachineScaleSetsClientListAllOptions{})
+	for scaleSetPager.More() {
+		page, err := scaleSetPager.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to advance page: %v", err)
+		}
+		for _, v := range page.Value {
+			vmScaleSets = append(vmScaleSets, *v.Name)
+		}
+	}
+	//TODO:
+	//list resource groups
+	//iterate over all the VM instances per resource group and scale set name
+	return nil
+}
+
 func getAllAzureVMInstances(ctx context.Context, client *armcompute.VirtualMachinesClient, subscriptionId string, regions []string, resourceGroup string) ([]AzureVMInstance, error) {
 	var vmInstances []AzureVMInstance
 	pager := client.NewListAllPager(&armcompute.VirtualMachinesClientListAllOptions{StatusOnly: to.Ptr("true")})

--- a/input/azure/vm.go
+++ b/input/azure/vm.go
@@ -177,16 +177,6 @@ func getAllAzureVMInstances(ctx context.Context, client *armcompute.VirtualMachi
 	return vmInstances, nil
 }
 
-func wantResourceGroup(v *armcompute.VirtualMachine, resourceGroup string) bool {
-	if resourceGroup == "" {
-		return true
-	}
-	if getResourceGroupFromId(*v.ID) == resourceGroup {
-		return true
-	}
-	return false
-}
-
 func wantRegion(v *armcompute.VirtualMachine, regions []string) bool {
 	if len(regions) == 0 {
 		return true

--- a/input/azure/vm_test.go
+++ b/input/azure/vm_test.go
@@ -58,6 +58,13 @@ var instanceid3 = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Mic
 const instance4Name = "instance4"
 const instanceVMId4 = "4"
 
+const ss1Name = "vmss1"
+const ss2Name = "vmss2"
+const ssVm1Name = "vmss_0"
+const ssVm2Name = "vmss_1"
+
+var ssID = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s", subscriptionId, resourceGroup1, ss1Name)
+
 var instanceIdDiffResourceGroup = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s", subscriptionId, resourceGroup2, instance4Name)
 
 var instance1 = armcompute.VirtualMachine{
@@ -88,17 +95,43 @@ var instanceDiffResourceGroup = armcompute.VirtualMachine{
 	Properties: &armcompute.VirtualMachineProperties{VMID: to.Ptr(instanceVMId4)},
 }
 
-func TestAssetsAzure_collectAzureAssets(t *testing.T) {
+var scaleSet = armcompute.VirtualMachineScaleSet{
+	Location: to.Ptr("westeurope"),
+	ID:       to.Ptr(ssID),
+	Name:     to.Ptr(ss1Name),
+}
+
+var scaleSetVm1 = armcompute.VirtualMachineScaleSetVM{
+	Location:   to.Ptr("westeurope"),
+	InstanceID: to.Ptr("0"),
+	Name:       to.Ptr(ssVm1Name),
+	Properties: &armcompute.VirtualMachineScaleSetVMProperties{VMID: to.Ptr(instanceVMId1)},
+}
+
+var scaleSetVm2 = armcompute.VirtualMachineScaleSetVM{
+	Location:   to.Ptr("northeurope"),
+	InstanceID: to.Ptr("1"),
+	Name:       to.Ptr(ssVm2Name),
+	Properties: &armcompute.VirtualMachineScaleSetVMProperties{VMID: to.Ptr(instanceVMId2)},
+}
+
+var status1 = armcompute.InstanceViewStatus{
+	DisplayStatus: to.Ptr("Provisioning"),
+}
+var status2 = armcompute.InstanceViewStatus{
+	DisplayStatus: to.Ptr("VM Running"),
+}
+
+func TestAssetsAzure_collectAzureVMAssets(t *testing.T) {
 	for _, tt := range []struct {
 		name           string
 		regions        []string
 		fakeServer     fake.VirtualMachinesServer
 		subscriptionId string
-		resourceGroup  string
 		expectedEvents []beat.Event
 	}{
 		{
-			name:           "Test with no regions specified and no resource group specified",
+			name:           "Test with no regions specified",
 			subscriptionId: "12cabcb4-86e8-404f-111111111111",
 			fakeServer: fake.VirtualMachinesServer{
 				NewListAllPager: func(options *armcompute.VirtualMachinesClientListAllOptions) (resp azfake.PagerResponder[armcompute.VirtualMachinesClientListAllResponse]) {
@@ -171,7 +204,7 @@ func TestAssetsAzure_collectAzureAssets(t *testing.T) {
 			},
 		},
 		{
-			name:           "Test with multiple regions specified but no resource group specified",
+			name:           "Test with multiple regions specified",
 			regions:        []string{"westeurope", "northeurope"},
 			subscriptionId: "12cabcb4-86e8-404f-111111111111",
 			fakeServer: fake.VirtualMachinesServer{
@@ -183,65 +216,6 @@ func TestAssetsAzure_collectAzureAssets(t *testing.T) {
 								&instance1,
 								&instance2,
 								&instance3,
-							},
-						},
-					}
-					resp.AddPage(http.StatusOK, page, nil)
-					return
-				},
-			},
-			expectedEvents: []beat.Event{
-				{
-					Fields: mapstr.M{
-						"asset.ean":                     "host:" + instanceVMId1,
-						"asset.id":                      instanceVMId1,
-						"asset.name":                    instance1Name,
-						"asset.type":                    "azure.vm.instance",
-						"asset.kind":                    "host",
-						"asset.metadata.state":          "",
-						"asset.metadata.resource_group": "TESTVM",
-						"cloud.account.id":              "12cabcb4-86e8-404f-111111111111",
-						"cloud.provider":                "azure",
-						"cloud.region":                  "westeurope",
-					},
-					Meta: mapstr.M{
-						"index": internal.GetDefaultIndexName(),
-					},
-				},
-				{
-					Fields: mapstr.M{
-						"asset.ean":                     "host:" + instanceVMId2,
-						"asset.id":                      instanceVMId2,
-						"asset.name":                    instance2Name,
-						"asset.type":                    "azure.vm.instance",
-						"asset.kind":                    "host",
-						"asset.metadata.state":          "",
-						"asset.metadata.resource_group": "TESTVM",
-						"cloud.account.id":              "12cabcb4-86e8-404f-111111111111",
-						"cloud.provider":                "azure",
-						"cloud.region":                  "northeurope",
-					},
-					Meta: mapstr.M{
-						"index": internal.GetDefaultIndexName(),
-					},
-				},
-			},
-		},
-		{
-			name:           "Test with multiple regions specified and resource group specified",
-			regions:        []string{"westeurope", "northeurope"},
-			resourceGroup:  resourceGroup1,
-			subscriptionId: "12cabcb4-86e8-404f-111111111111",
-			fakeServer: fake.VirtualMachinesServer{
-				NewListAllPager: func(options *armcompute.VirtualMachinesClientListAllOptions) (resp azfake.PagerResponder[armcompute.VirtualMachinesClientListAllResponse]) {
-
-					page := armcompute.VirtualMachinesClientListAllResponse{
-						VirtualMachineListResult: armcompute.VirtualMachineListResult{
-							Value: []*armcompute.VirtualMachine{
-								&instance1,
-								&instance2,
-								&instance3,
-								&instanceDiffResourceGroup,
 							},
 						},
 					}
@@ -300,7 +274,126 @@ func TestAssetsAzure_collectAzureAssets(t *testing.T) {
 			})
 			assert.NoError(t, err)
 
-			err = collectAzureVMAssets(ctx, client, tt.subscriptionId, tt.regions, tt.resourceGroup, logger, publisher)
+			err = collectAzureVMAssets(ctx, client, tt.subscriptionId, tt.regions, logger, publisher)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedEvents, publisher.Events)
+		})
+
+	}
+}
+
+func TestAssetsAzure_collectAzureScaleSetsVMAssets(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		regions        []string
+		fakeSSServer   fake.VirtualMachineScaleSetsServer
+		fakeVMServer   fake.VirtualMachineScaleSetVMsServer
+		subscriptionId string
+		expectedEvents []beat.Event
+	}{
+		{
+			name:           "Test with one ScaleSet with tow instances",
+			subscriptionId: "12cabcb4-86e8-404f-111111111111",
+			fakeSSServer: fake.VirtualMachineScaleSetsServer{
+				NewListAllPager: func(options *armcompute.VirtualMachineScaleSetsClientListAllOptions) (resp azfake.PagerResponder[armcompute.VirtualMachineScaleSetsClientListAllResponse]) {
+
+					page := armcompute.VirtualMachineScaleSetsClientListAllResponse{
+						VirtualMachineScaleSetListWithLinkResult: armcompute.VirtualMachineScaleSetListWithLinkResult{
+							Value: []*armcompute.VirtualMachineScaleSet{
+								&scaleSet,
+							},
+						},
+					}
+					resp.AddPage(http.StatusOK, page, nil)
+					return
+				},
+			},
+			fakeVMServer: fake.VirtualMachineScaleSetVMsServer{
+				NewListPager: func(resourceGroup string, vmScaleSetName string, options *armcompute.VirtualMachineScaleSetVMsClientListOptions) (resp azfake.PagerResponder[armcompute.VirtualMachineScaleSetVMsClientListResponse]) {
+
+					page := armcompute.VirtualMachineScaleSetVMsClientListResponse{
+						VirtualMachineScaleSetVMListResult: armcompute.VirtualMachineScaleSetVMListResult{
+							Value: []*armcompute.VirtualMachineScaleSetVM{
+								&scaleSetVm1,
+								&scaleSetVm2,
+							},
+						},
+					}
+					resp.AddPage(http.StatusOK, page, nil)
+					return
+				},
+				GetInstanceView: func(ctx context.Context, resourceGroupName, vmScaleSetName, instanceId string, options *armcompute.VirtualMachineScaleSetVMsClientGetInstanceViewOptions) (resp azfake.Responder[armcompute.VirtualMachineScaleSetVMsClientGetInstanceViewResponse], errResp azfake.ErrorResponder) {
+
+					response := armcompute.VirtualMachineScaleSetVMsClientGetInstanceViewResponse{
+						VirtualMachineScaleSetVMInstanceView: armcompute.VirtualMachineScaleSetVMInstanceView{
+							Statuses: []*armcompute.InstanceViewStatus{
+								&status1,
+								&status2,
+							},
+						},
+					}
+					resp.SetResponse(http.StatusOK, response, nil)
+					return
+				},
+			},
+			expectedEvents: []beat.Event{
+				{
+					Fields: mapstr.M{
+						"asset.ean":                     "host:" + instanceVMId1,
+						"asset.id":                      instanceVMId1,
+						"asset.name":                    ssVm1Name,
+						"asset.type":                    "azure.vm.instance",
+						"asset.kind":                    "host",
+						"asset.metadata.state":          "VM Running",
+						"asset.metadata.resource_group": "TESTVM",
+						"cloud.account.id":              "12cabcb4-86e8-404f-111111111111",
+						"cloud.provider":                "azure",
+						"cloud.region":                  "westeurope",
+					},
+					Meta: mapstr.M{
+						"index": internal.GetDefaultIndexName(),
+					},
+				},
+				{
+					Fields: mapstr.M{
+						"asset.ean":                     "host:" + instanceVMId2,
+						"asset.id":                      instanceVMId2,
+						"asset.name":                    ssVm2Name,
+						"asset.type":                    "azure.vm.instance",
+						"asset.kind":                    "host",
+						"asset.metadata.state":          "VM Running",
+						"asset.metadata.resource_group": "TESTVM",
+						"cloud.account.id":              "12cabcb4-86e8-404f-111111111111",
+						"cloud.provider":                "azure",
+						"cloud.region":                  "northeurope",
+					},
+					Meta: mapstr.M{
+						"index": internal.GetDefaultIndexName(),
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			publisher := testutil.NewInMemoryPublisher()
+
+			ctx := context.Background()
+			logger := logp.NewLogger("test")
+
+			vmclient, err := armcompute.NewVirtualMachineScaleSetVMsClient("subscriptionID", azfake.NewTokenCredential(), &arm.ClientOptions{
+				ClientOptions: azcore.ClientOptions{
+					Transport: fake.NewVirtualMachineScaleSetVMsServerTransport(&tt.fakeVMServer),
+				},
+			})
+
+			ssclient, err := armcompute.NewVirtualMachineScaleSetsClient("subscriptionID", azfake.NewTokenCredential(), &arm.ClientOptions{
+				ClientOptions: azcore.ClientOptions{
+					Transport: fake.NewVirtualMachineScaleSetsServerTransport(&tt.fakeSSServer),
+				},
+			})
+			assert.NoError(t, err)
+
+			err = collectAzureScaleSetsVMAssets(ctx, vmclient, ssclient, tt.subscriptionId, tt.regions, logger, publisher)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedEvents, publisher.Events)
 		})

--- a/input/azure/vm_test.go
+++ b/input/azure/vm_test.go
@@ -37,7 +37,6 @@ import (
 )
 
 const resourceGroup1 = "TESTVM"
-const resourceGroup2 = "WRONGVM"
 const subscriptionId = "12cabcb4-86e8-404f-111111111111"
 const instance1Name = "instance1"
 
@@ -55,17 +54,11 @@ const instanceVMId3 = "3"
 
 var instanceid3 = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s", subscriptionId, resourceGroup1, instance3Name)
 
-const instance4Name = "instance4"
-const instanceVMId4 = "4"
-
 const ss1Name = "vmss1"
-const ss2Name = "vmss2"
 const ssVm1Name = "vmss_0"
 const ssVm2Name = "vmss_1"
 
 var ssID = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachineScaleSets/%s", subscriptionId, resourceGroup1, ss1Name)
-
-var instanceIdDiffResourceGroup = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s", subscriptionId, resourceGroup2, instance4Name)
 
 var instance1 = armcompute.VirtualMachine{
 	Location:   to.Ptr("westeurope"),
@@ -86,13 +79,6 @@ var instance3 = armcompute.VirtualMachine{
 	ID:         to.Ptr(instanceid3),
 	Name:       to.Ptr(instance3Name),
 	Properties: &armcompute.VirtualMachineProperties{VMID: to.Ptr(instanceVMId3)},
-}
-
-var instanceDiffResourceGroup = armcompute.VirtualMachine{
-	Location:   to.Ptr("northeurope"),
-	ID:         to.Ptr(instanceIdDiffResourceGroup),
-	Name:       to.Ptr(instance4Name),
-	Properties: &armcompute.VirtualMachineProperties{VMID: to.Ptr(instanceVMId4)},
 }
 
 var scaleSet = armcompute.VirtualMachineScaleSet{
@@ -380,7 +366,7 @@ func TestAssetsAzure_collectAzureScaleSetsVMAssets(t *testing.T) {
 			ctx := context.Background()
 			logger := logp.NewLogger("test")
 
-			vmclient, err := armcompute.NewVirtualMachineScaleSetVMsClient("subscriptionID", azfake.NewTokenCredential(), &arm.ClientOptions{
+			vmclient, _ := armcompute.NewVirtualMachineScaleSetVMsClient("subscriptionID", azfake.NewTokenCredential(), &arm.ClientOptions{
 				ClientOptions: azcore.ClientOptions{
 					Transport: fake.NewVirtualMachineScaleSetVMsServerTransport(&tt.fakeVMServer),
 				},


### PR DESCRIPTION
This PR enhances azure VM's collector in order to collect VM instances of VM Scale Sets.
This is important because usually kubernetes nodes of AKS cluster are VM Scale Sets Instances under the hood.

We would like to collect those to be able to link those assets with AKS kubernetes nodes and thus clusters.