### PR TITLE
Populate cloud.instance.id in azure nodes

### DIFF
--- a/input/k8s/nodes.go
+++ b/input/k8s/nodes.go
@@ -143,7 +143,7 @@ func publishK8sNodes(ctx context.Context, log *logp.Logger, publisher stateless.
 			metadata := mapstr.M{
 				"state": getNodeState(o),
 			}
-			log.Info("Node status: ", metadata["state"])
+			log.Debug("Node status: ", metadata["state"])
 			instanceId := getInstanceId(o)
 			log.Debug("Node instance id: ", instanceId)
 			assetId := string(o.ObjectMeta.UID)

--- a/input/k8s/util.go
+++ b/input/k8s/util.go
@@ -76,6 +76,8 @@ func getInstanceId(node *kubernetes.Node) string {
 	case "gcp":
 		annotations := node.GetAnnotations()
 		return annotations["container.googleapis.com/instance_id"]
+	case "azure":
+		return node.Status.NodeInfo.SystemUUID
 	default:
 		return ""
 	}
@@ -99,12 +101,16 @@ func getNodeState(node *kubernetes.Node) string {
 // getCspFromProviderId return the cps for a given providerId string.
 // In case of aws providerId is in the form of aws:///region/instanceId
 // In case of gcp providerId is in the form of  gce://project/region/nodeName
+// In case of azure providerId is in the form of  azure:///subscriptions/subscriptionId
 func getCspFromProviderId(providerId string) string {
 	if strings.HasPrefix(providerId, "aws") {
 		return "aws"
 	}
 	if strings.HasPrefix(providerId, "gce") {
 		return "gcp"
+	}
+	if strings.HasPrefix(providerId, "azure") {
+		return "azure"
 	}
 	return ""
 }

--- a/input/k8s/util_test.go
+++ b/input/k8s/util_test.go
@@ -130,6 +130,34 @@ func TestGetInstanceId(t *testing.T) {
 			output: "5445971517456914360",
 		},
 		{
+			name: "Azure Node",
+			input: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "node1",
+					UID:  "60988eed-1885-4b63-9fa4-780206969deb",
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+					Annotations: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Node",
+					APIVersion: "v1",
+				},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{{Type: v1.NodeHostName, Address: "node1"}},
+					NodeInfo:  v1.NodeSystemInfo{SystemUUID: "ebf2fd19-ee80-4751-91e5-087c4fe39845"},
+				},
+				Spec: v1.NodeSpec{
+					ProviderID: "azure:///subscriptions/11232-12321-sdsads-123/resourceGroups/mc_michaliskatsoulisgroup_katsoulistest2_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-agentpool-56241798-vmss/virtualMachines/0",
+				},
+			},
+			output: "ebf2fd19-ee80-4751-91e5-087c4fe39845",
+		},
+		{
 			name: "No CSP Node (kind)",
 			input: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This PR retrieves from AKS nodes the associated virtual machine's instance id.
The information is retrieved from SystemUUID of the kubernetes node.