### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 
 assetbeat is a small binary for running stateless [Elastic Agent v2 inputs](https://github.com/elastic/elastic-agent-inputs/issues/1).
 
+This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+
 It’s still a beat, for now.
 But the intention is that this is as lightweight as possible, until the day when standalone inputs can utilise the [Elastic Agent v2 shipper](https://github.com/elastic/elastic-agent-shipper).
 
 ## Inputs
 
-Documentation for each input can be found in the releveant directory (e.g. input/aws).
+Documentation for each input can be found in the relevant directory (e.g. input/aws).
 
 ## Development
 
 Requirements:
-- go 1.19+
+- go 1.20+
 - [Mage](https://magefile.org/)
 
-Mage targets are self-explanitory and can be listed with `mage -l`.
+Mage targets are self-explanatory and can be listed with `mage -l`.
 
 Build the assetbeat binary with `mage build`, and run it locally with `./assetbeat`.
 See `./assetbeat -h` for more detail on configuration options.
@@ -26,7 +28,7 @@ NOTICE.txt. Also double-check that `mage check` returns with no errors, as the P
 Please aim for 100% unit test coverage on new code.
 You can view the HTML coverage report by running `mage unitTest && [xdg-]open ./coverage.html`.
 
-### Requirements for inputs (WIP)
+### Requirements for inputs
 
 - Compatible with [Elastic Agent v2 inputs](https://github.com/elastic/elastic-agent-inputs/issues/1)
 - No [Cgo](https://pkg.go.dev/cmd/cgo) allowed

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# assetbeat
+[![Build status](https://badge.buildkite.com/c02badfd4c5a879748bbc27ecfc19147c296af2410391dc749.svg?branch=main)](https://buildkite.com/elastic/assetbeat)
+[![Go Report Card](https://goreportcard.com/badge/github.com/elastic/assetbeat)](https://goreportcard.com/report/github.com/elastic/assetbeat)
 
-assetbeat is a small binary for running stateless [Elastic Agent v2 inputs](https://github.com/elastic/elastic-agent-inputs/issues/1).
+# Assetbeat
 
-This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+Assetbeat is a small binary for collecting information about infrastructure "assets". Assets are defined as elements within your infrastructure, such as containers, machines, pods, clusters, etc.
 
-It’s still a beat, for now.
-But the intention is that this is as lightweight as possible, until the day when standalone inputs can utilise the [Elastic Agent v2 shipper](https://github.com/elastic/elastic-agent-shipper).
+**Note:** Assetbeat is currently in technical preview and may be subject to frequent changes. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
 
 ## Inputs
 
@@ -30,7 +30,7 @@ You can view the HTML coverage report by running `mage unitTest && [xdg-]open ./
 
 ### Requirements for inputs
 
-- Compatible with [Elastic Agent v2 inputs](https://github.com/elastic/elastic-agent-inputs/issues/1)
+- Compatible with [Elastic Agent v2](https://github.com/elastic/elastic-agent/blob/main/docs/architecture.md)
 - No [Cgo](https://pkg.go.dev/cmd/cgo) allowed
 - Stateless (including publisher)
 - Config must be compatible with Elastic Agent


### PR DESCRIPTION
Update README a note about the project being in technical preview. All references to `elastic-agent-shipper` and `elastic-agent-inputs` were removed, since both repositories are currently` read-only`