### PR TITLE
backport: Add 8.11 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -71,3 +71,16 @@ pull_request_rules:
         method: squash
         name: default
     
+  - name: backport patches to 8.11 branch
+    conditions:
+      - merged
+      - label=backport-v8.11.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.11"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
Merge as soon as 8.11 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821