### PR TITLE
Add base folder to tar artifacts

### DIFF
--- a/internal/dev-tools/package.go
+++ b/internal/dev-tools/package.go
@@ -93,21 +93,21 @@ func packageTar(spec PackageSpec) error {
 		return err
 	}
 
-	tarFileName := getPackageTarName(spec)
-	tarFilePath := filepath.Join(defaultPackageFolder, tarFileName)
-	err := CreateTarball(tarFilePath, filesPathList)
+	basePackageName := getPackageBaseName(spec)
+	tarFilePath := filepath.Join(defaultPackageFolder, basePackageName+".tar.gz")
+	err := CreateTarball(basePackageName, tarFilePath, filesPathList)
 	if err != nil {
 		return err
 	}
 	return CreateSHA512File(tarFilePath)
 }
 
-func getPackageTarName(spec PackageSpec) string {
+func getPackageBaseName(spec PackageSpec) string {
 	tarFileNameElements := []string{"assetbeat", version.GetVersion()}
 	if spec.IsSnapshot {
 		tarFileNameElements = append(tarFileNameElements, "SNAPSHOT")
 	}
 	tarFileNameElements = append(tarFileNameElements, []string{spec.Os, spec.Arch}...)
 
-	return strings.Join(tarFileNameElements, "-") + ".tar.gz"
+	return strings.Join(tarFileNameElements, "-")
 }

--- a/internal/dev-tools/package.go
+++ b/internal/dev-tools/package.go
@@ -51,7 +51,7 @@ func GetPackageArch(goarch string) string {
 // GetDefaultExtraFiles returns the default list of files to include in an assetbeat package,
 // in addition to assetbeat's executable
 func GetDefaultExtraFiles() []string {
-	return []string{"LICENSE.txt", "README.md", "assetbeat.yml", "assetbeat.spec.yml"}
+	return []string{"assetbeat.yml", "assetbeat.spec.yml"}
 }
 
 // CreatePackage assetbeat for distribution. It generates packages based on the provided PackageSpec/

--- a/internal/dev-tools/tar.go
+++ b/internal/dev-tools/tar.go
@@ -28,7 +28,7 @@ import (
 )
 
 // CreateTarball creates a tar.gz compressed archive from a list of files.
-func CreateTarball(outputTarballFilePath string, filePaths []string) error {
+func CreateTarball(baseFolderName string, outputTarballFilePath string, filePaths []string) error {
 	fmt.Printf("Creating tarball... Filepath: %s\n", outputTarballFilePath)
 	file, err := os.Create(outputTarballFilePath)
 	if err != nil {
@@ -43,7 +43,7 @@ func CreateTarball(outputTarballFilePath string, filePaths []string) error {
 	defer tarWriter.Close()
 
 	for _, filePath := range filePaths {
-		err := addFileToTarWriter(filePath, tarWriter)
+		err := addFileToTarWriter(baseFolderName, filePath, tarWriter)
 		if err != nil {
 			return fmt.Errorf("could not add file '%s', to tarball, got error '%s'", filePath, err)
 		}
@@ -52,7 +52,7 @@ func CreateTarball(outputTarballFilePath string, filePaths []string) error {
 	return nil
 }
 
-func addFileToTarWriter(filePath string, tarWriter *tar.Writer) error {
+func addFileToTarWriter(baseFolderName string, filePath string, tarWriter *tar.Writer) error {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return fmt.Errorf("could not open file '%s', got error '%s'", filePath, err)
@@ -70,7 +70,7 @@ func addFileToTarWriter(filePath string, tarWriter *tar.Writer) error {
 		headerName = "assetbeat"
 	}
 	header := &tar.Header{
-		Name:    headerName,
+		Name:    baseFolderName + "/" + headerName,
 		Size:    stat.Size(),
 		Mode:    int64(stat.Mode()),
 		ModTime: stat.ModTime(),


### PR DESCRIPTION
The current packaging logic does not preserve the folder structure. Uncompressing the tar archive would lead to a flat structure.
```
❯ tar xvf assetbeat-8.12.0-linux-x86_64.tar.gz
x assetbeat
x LICENSE.txt
x README.md
x assetbeat.yml
x assetbeat.spec.yml
```
Agent's packaging logic expects each tarball file to contain a folder with pattern `<component name>-<version>--<os>--<platform>`, similar to the following
```
❯ tar xvf assetbeat-8.12.0-linux-x86_64.tar.gz
x assetbeat-8.12.0-linux-x86_64/assetbeat
x assetbeat-8.12.0-linux-x86_64/LICENSE.txt
x assetbeat-8.12.0-linux-x86_64/README.md
x assetbeat-8.12.0-linux-x86_64/assetbeat.yml
x assetbeat-8.12.0-linux-x86_64/assetbeat.spec.yml

```

This change modifies the packaging logic to be compatible with Agent, and prevents README and LICENSE to be bundled into the generated tarballs.

Reference: https://github.com/elastic/elastic-agent/blob/main/magefile.go#L1090
